### PR TITLE
Version 0.6.1: Fixed bug and changed logging level.

### DIFF
--- a/Sources/Server/Account Specifics/GoogleCreds.swift
+++ b/Sources/Server/Account Specifics/GoogleCreds.swift
@@ -171,12 +171,26 @@ class GoogleCreds : AccountAPICall, Account {
     }
     
     func needToGenerateTokens(userType:UserType, dbCreds:Account? = nil) -> Bool {
+        var result:Bool
         if userType == .sharing {
-            return false
+            result = false
+        }
+        else {
+            result = serverAuthCode != nil
+            
+            // If no dbCreds, then we generate tokens.
+            if let dbCreds = dbCreds {
+                if let dbGoogleCreds = dbCreds as? GoogleCreds {
+                    result = result && serverAuthCode != dbGoogleCreds.serverAuthCode
+                }
+                else {
+                    Log.error("Did not get GoogleCreds as dbCreds!")
+                }
+            }
         }
         
-        let dbGoogleCreds = dbCreds as! GoogleCreds
-        return serverAuthCode != nil && serverAuthCode != dbGoogleCreds.serverAuthCode
+        Log.debug("needToGenerateTokens: \(result); serverAuthCode: \(String(describing: serverAuthCode))")
+        return result
     }
     
     // Use the serverAuthCode to generate a refresh and access token if there is one. If no error occurs, success is true iff the generation occurred successfully.

--- a/Sources/Server/Controllers/UserController.swift
+++ b/Sources/Server/Controllers/UserController.swift
@@ -108,8 +108,10 @@ class UserController : ControllerProtocol {
         
         let response = AddUserResponse()!
 
+        Log.info("About to check if we need to generate tokens...")
+        
         // I am not doing token generation earlier (e.g., in the RequestHandler) because in most cases, we don't have a user database record created earlier, so if needed cannot save the tokens generated.
-        profileCreds.generateTokensIfNeeded(userType: userType, dbCreds: user.credsObject, routerResponse: params.routerResponse, success: {
+        profileCreds.generateTokensIfNeeded(userType: userType, dbCreds: nil, routerResponse: params.routerResponse, success: {
             params.completion(response)
         }, failure: {
             params.completion(nil)

--- a/Sources/Server/ServerMain.swift
+++ b/Sources/Server/ServerMain.swift
@@ -34,7 +34,8 @@ public class ServerMain {
     }
     
     public class func startup(type:ServerStartup = .blocking) {
-        Log.logger = HeliumLogger()
+        // Set the logging level
+        HeliumLogger.use(.debug)
         
         Log.info("Launching server in \(type) mode with \(CommandLine.arguments.count) command line arguments.")
         

--- a/Tests/ServerTests/KituraTest.swift
+++ b/Tests/ServerTests/KituraTest.swift
@@ -50,6 +50,10 @@ struct TestAccount {
     static let google2 = TestAccount(tokenKey: "GoogleRefreshToken2", idKey: "GoogleSub2", type: .Google)
     static let google3 = TestAccount(tokenKey: "GoogleRefreshToken3", idKey: "GoogleSub3", type: .Google)
     
+    static func isGoogle(_ account: TestAccount) -> Bool {
+        return account == google1 || account == google2 || account == google3
+    }
+    
     static let facebook1 = TestAccount(tokenKey: "FacebookLongLivedToken1", idKey: "FacebookId1", type: .Facebook)
     
     // I've put this method here (instead of in Constants) because it is just a part of testing, not part of the full-blown server.

--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -1,7 +1,7 @@
 SyncServer
 
-8/31/17
-	* Google auth code was being sent to server when an owning user account was created, but was not being converted to a refresh token and saved.
+Version 0.6.1; 9/2/17
+	* Fixed issue: Google auth code was being sent to server when an owning user account was created, but was not being converted to a refresh token and saved.
 	
 	* Set logging level to DEBUG.
 

--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -1,3 +1,10 @@
+SyncServer
+
+8/31/17
+	* Google auth code was being sent to server when an owning user account was created, but was not being converted to a refresh token and saved.
+	
+	* Set logging level to DEBUG.
+
 Version 0.6; 8/9/17-- Bug fixes
 	* Don't store additional creds info for Google shared users
 		https://github.com/crspybits/SyncServerII/issues/13


### PR DESCRIPTION
Version 0.6.1; 9/2/17
	* Fixed issue: Google auth code was being sent to server when an owning user account was created, but was not being converted to a refresh token and saved.
	
	* Set logging level to DEBUG.